### PR TITLE
stop moving auto align after entering tolerances

### DIFF
--- a/src/main/java/frc/robot/autoalign/MovingAutoAlign.java
+++ b/src/main/java/frc/robot/autoalign/MovingAutoAlign.java
@@ -81,7 +81,8 @@ public class MovingAutoAlign {
             Supplier<ChassisSpeeds> speedsModifier,
             Supplier<TrapezoidProfile.Constraints> xyConstraints) {
         return moveToPose(swerve, target, speedsModifier, xyConstraints)
-            .until(() -> AutoAlignUtils.isInTolerance(swerve.getState().Pose, target.get(), swerve.getState().Speeds));
+            .until(() -> AutoAlignUtils.isInTolerance(swerve.getState().Pose, target.get()))
+            .andThen(swerve.stopCmd());
     }
 
     /**


### PR DESCRIPTION
this could be added to legacy auto align if we have this problem in auton but i would not like to screw with auton considering it just hit the 3.5